### PR TITLE
Fixed CSV filename issue when exporting

### DIFF
--- a/modules/browser.js
+++ b/modules/browser.js
@@ -24,11 +24,13 @@ export async function getTotalMessages(folder) {
   return messages;
 }
 
-export function downloadCSV(csv) {
+export function downloadCSV(csv, folderName) {
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const filename = folderName ? `${folderName}.csv` : "export.csv";
+
   messenger.downloads.download({
     url: URL.createObjectURL(blob),
-    filename: `${folder.name}.csv`,
+    filename: filename,
     saveAs: true,
   });
 }

--- a/popup.js
+++ b/popup.js
@@ -10,6 +10,7 @@ window.addEventListener("load", onLoad);
 let folderSpan, totalSpan, currentSpan, progressBar, errorSpan, statusSpan;
 
 let senders;
+let folderName; // Store the folder name here
 
 async function onLoad() {
   initializeUIElements();
@@ -41,7 +42,7 @@ async function handleClose(event) {
 
 async function handleDownloadCSV() {
   const csv = objectArrayToCSV({ data: senders });
-  downloadCSV(csv);
+  downloadCSV(csv, folderName);
 }
 
 async function startParsingMessages() {
@@ -56,6 +57,7 @@ async function startParsingMessages() {
 
     // Gets the current displayed folder on the active tab on the active window
     const folder = tabs?.[0]?.displayedFolder;
+    folderName = folder.name; // Save folder name for use in download
     folderSpan.textContent = folder.name;
 
     statusSpan.textContent = "Getting Total Messages..";


### PR DESCRIPTION
## Fix CSV Filename Issue When Exporting Messages

### Overview
This pull request addresses the issue where the filename for the CSV export was being set as "undefined" because the `folder` object was not passed as a parameter in the `downloadCSV()` function. This issue was reported in [Issue #4](https://github.com/2AStudios/tb-export2csv/issues/4).

### Changes Made
- Modified the `downloadCSV()` function to accept the folder name as a parameter.
- Updated the logic in `popup.js` to pass the folder name from the selected folder during message export, ensuring the filename is generated correctly based on the folder name (e.g., `Inbox.csv`).
- Added a fallback to "export.csv" if the folder name is not available, preventing the filename from being undefined.

### Testing
- Tested the export functionality to verify that the correct folder name is used in the CSV file name.
- Ensured that if the folder name is unavailable, the default filename `export.csv` is used.

### Issue Reference
Fixes [#4](https://github.com/2AStudios/tb-export2csv/issues/4)
